### PR TITLE
Update efibootmgr.c

### DIFF
--- a/src/efibootmgr.c
+++ b/src/efibootmgr.c
@@ -1192,6 +1192,7 @@ get_entry(list_t *entries, uint16_t num)
 			entry = NULL;
 			continue;
 		}
+		return entry;
 	}
 
 	return entry;


### PR DESCRIPTION
get_entry: return entry if it was found before reaching the end of the list

Signed-off-by: kmicki <1463619+kmicki@users.noreply.github.com>